### PR TITLE
A fews smoke tests for Linux-Proc-Maps 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,5 +16,8 @@ install:
    - cpanm --quiet --notest --skip-satisfied Dist::Zilla
    - "dzil authordeps          --missing | grep -vP '[^\\w:]' | xargs -n 5 -P 10 cpanm --quiet --notest"
    - "dzil listdeps   --author --missing | grep -vP '[^\\w:]' | cpanm --verbose"
+   - cpanm --notest -q Sparrow
+   - sparrow plg install linux-proc-maps-smoke
 script:
    - dzil smoke --release --author
+   - sparrow plg run linux-proc-maps-smoke

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,4 +20,4 @@ install:
    - sparrow plg install linux-proc-maps-smoke
 script:
    - dzil smoke --release --author
-   - sparrow plg run linux-proc-maps-smoke
+   - "export PERL5LIB=$PWD/lib && sparrow plg run linux-proc-maps-smoke"


### PR DESCRIPTION
Hi @chazmcgarvey !

This is [small test suite](https://github.com/melezhik/linux-proc-maps-smoke) written on [Sparrow](https://metacpan.org/pod/Sparrow) - a blackbox testing / automation framework. I occasionally find some CPAN modules and write tests for them.  

What the test does:

* call format_maps_single_line with some hash input data and validate that  it returns valid maps single line
* call parse_maps_single_line with some maps single line and validate that it returns valid hash values
* fork child process and pass it's PID to read_maps then validates it recognizes a pathname related to process forked ( sleep command )

---

PS if you like this test please merge in or if you have any questions feel free to ask. If you don't like the idea just close the PR, I will be ok with that. An example travis reports could be found here - https://travis-ci.org/melezhik/Linux-Proc-Maps/jobs/182714330


Alexey


  
